### PR TITLE
Update modmail.js 

### DIFF
--- a/commands/Moderation/modmail.js
+++ b/commands/Moderation/modmail.js
@@ -7,7 +7,6 @@ module.exports = {
     async run (client, message, args) {
 
         if(!message.member.hasPermission("MANAGE_GUILD")) return message.channel.send('You can\'t use that jimbo')
-        if(!message.guild.me.hasPermission("MANAGE_GUILD")) return message.channel.send('I don\'t have the right permissions.')
 
         const member = message.mentions.members.first() || message.guild.members.cache.get(args[0]);
 


### PR DESCRIPTION
Bot doesn't need Manage Server permissions to Modmail a user, it's dm'ing the user so the only permissions the bot would need would be Read/ Send Messages.